### PR TITLE
Update cmac_krnl.sv

### DIFF
--- a/kernel/cmac_krnl/src/hdl/cmac_krnl.sv
+++ b/kernel/cmac_krnl/src/hdl/cmac_krnl.sv
@@ -92,7 +92,7 @@ network_module inst_network_module
 (
     .dclk (clk_gt_freerun),
     .net_clk(net_clk),
-    .sys_reset (1'b0),
+    .sys_reset (areset),
     .aresetn(net_aresetn_reg),
     .network_init_done(network_init),
     


### PR DESCRIPTION
Don't know why you put 0 in sys_reset but clearly many logic and the cmac ip depend on this signal to be initialized